### PR TITLE
Fix texture descriptor defaults

### DIFF
--- a/functions/features/compute_descriptors.m
+++ b/functions/features/compute_descriptors.m
@@ -59,7 +59,7 @@ function descriptors = compute_descriptors(img, mask, label, options)
   end
 
   if ismember('texture', modules)
-    texture_table = compute_texture_descriptors(img, mask, texture_features={'rilbp' 'edgehistStats', 'zernike'});
+    texture_table = compute_texture_descriptors(img, mask, texture_features={'rilbp', 'edgehistStats', 'zernike'});
     descriptors = [descriptors, texture_table];
   end
 

--- a/functions/features/compute_texture_descriptors.m
+++ b/functions/features/compute_texture_descriptors.m
@@ -11,17 +11,17 @@ function texture_table = compute_texture_descriptors(img, mask, options)
 %         'rilbp'  : Local Binary Pattern rotation-invariant (TODO)
 %         'edgehistStats' : statistiche sui gradienti del bordo (media, varianza, ecc.)
 %
-%     Default: {'hist', 'glcm', 'avgedge'}
+%     Default: {'hist', 'glcm', 'rilbp', 'edgehistStats', 'zernike'}
 
   arguments
     img (:,:,3) uint8
     mask (:,:) logical
-    options.texture_features cell = {'hist', 'glcm', 'rilbp' 'edgehistStats', 'zernike'}
+    options.texture_features cell = {'hist', 'glcm', 'rilbp', 'edgehistStats', 'zernike'}
   end
 
   valid_features = {'hist', 'glcm', 'rilbp', 'edgehistStats', 'zernike'};
   if ~all(ismember(options.texture_features, valid_features))
-    error('Valori non validi in options.texture_features. Ammessi: hist, glcm, rilbp, avgedge.');
+    error('Valori non validi in options.texture_features. Ammessi: hist, glcm, rilbp, edgehistStats, zernike.');
   end
 
   % Conversione in scala di grigi


### PR DESCRIPTION
## Summary
- ensure default texture features include comma separation
- update error message to reflect available options

## Testing
- `matlab -batch "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9c1dfae48331aff568d2a7b0cf12